### PR TITLE
feat: Add '発 言 強 調' (Emphasized Statement) novelty text conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,8 @@
       { id: 'korean', label: '韓国語風' },
       { id: 'alien', label: '宇宙人語風' },
       { id: 'reverse', label: '逆さ文字' },
-      { id: 'dakuten', label: '濁点まみれ' }
+      { id: 'dakuten', label: '濁点まみれ' },
+      { id: 'emphasizedStatement', label: '発 言 強 調' }
     ]
   };
 
@@ -340,6 +341,7 @@
     alien: "変換したい言葉を入力（宇宙人語風に）",
     reverse: "変換したい言葉を入力（逆さにします）",
     dakuten: "変換したい言葉を入力（濁点まみれに）",
+    emphasizedStatement: "強調したい言葉を入力（スペースで区切ります）",
     default: "ここに変換したい文章を入力"
   };
 
@@ -472,6 +474,12 @@
     }).join('');
   }
 
+  function emphasizedStatementConversion(str) {
+    if (str === null || str === undefined) {
+      return '';
+    }
+    return str.split('').join(' ');
+  }
 
   const conversionStrategies = {
     'upper': (text) => text.toUpperCase(),
@@ -487,6 +495,7 @@
     'alien': (text) => randomConvert(text, funnySymbols.alien),
     'reverse': reverseString,
     'dakuten': addDakutenOnly,
+    'emphasizedStatement': emphasizedStatementConversion,
   };
 
 


### PR DESCRIPTION
This commit introduces a new text conversion option to the 'fun' (ネタ) category:
- '発 言 強 調' (Emphasized Statement)

This conversion inserts a half-width space between every character in the input string. This applies to all character types, including Japanese (Kanji, Hiragana, Katakana), English letters, numbers, symbols, and existing spaces.

Changes made:
- Added 'emphasizedStatement' to the `tabDefinitions.fun` array in `index.html`.
- Implemented the `emphasizedStatementConversion(str)` JavaScript function to perform the character spacing.
- Mapped this function in the `conversionStrategies` object.
- Added a corresponding placeholder text in `placeholderTexts`.
- Verified through user testing that the option appears correctly in the UI and the conversion logic works as expected.